### PR TITLE
first implementation of randomized_eigh(selection=value) with tests

### DIFF
--- a/benchmarks/bench_isomap_auto_vs_randomized.py
+++ b/benchmarks/bench_isomap_auto_vs_randomized.py
@@ -1,0 +1,98 @@
+"""
+======================================================================
+Benchmark: Comparing Isomap Solvers - Execution Time vs. Representation
+======================================================================
+
+This benchmark demonstrates how different eigenvalue solvers in Isomap 
+can affect execution time and embedding quality.
+
+Description:
+------------
+We use a subset of handwritten digits (`load_digits` with 6 classes). 
+Each data point is projected into a lower-dimensional space (2D) using 
+two different solvers (`auto` and `randomized`).
+
+What you can observe:
+----------------------
+- The `auto` solver provides a reference solution.
+- The `randomized` solver is tested for comparison in terms of 
+  representation quality and execution time.
+
+Further exploration:
+---------------------
+You can modify the number of neighbors (`n_neighbors`) or experiment with 
+other Isomap solvers.
+"""
+
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import offsetbox
+from sklearn.datasets import load_digits
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.manifold import Isomap
+
+# 1- Data Loading
+# ---------------
+digits = load_digits(n_class=6)
+X, y = digits.data, digits.target
+n_neighbors = 30  # Number of neighbors for Isomap
+
+# 2- Visualization Function
+# -------------------------
+def plot_embedding(ax, X, title):
+    """Displays projected points with image annotations."""
+    X = MinMaxScaler().fit_transform(X)
+
+    for digit in digits.target_names:
+        ax.scatter(
+            *X[y == digit].T,
+            marker=f"${digit}$",
+            s=60,
+            color=plt.cm.Dark2(digit),
+            alpha=0.425,
+            zorder=2,
+        )
+
+    # Add digit images in the projected space
+    shown_images = np.array([[1.0, 1.0]])
+    for i in range(X.shape[0]):
+        dist = np.sum((X[i] - shown_images) ** 2, 1)
+        if np.min(dist) < 4e-3:
+            continue
+        shown_images = np.concatenate([shown_images, [X[i]]], axis=0)
+        imagebox = offsetbox.AnnotationBbox(
+            offsetbox.OffsetImage(digits.images[i], cmap=plt.cm.gray_r), X[i]
+        )
+        imagebox.set(zorder=1)
+        ax.add_artist(imagebox)
+
+    ax.set_title(title)
+    ax.axis("off")
+
+# 3- Define Embeddings and Benchmark
+# ----------------------------------
+embeddings = {
+    "Isomap (auto solver)": Isomap(n_neighbors=n_neighbors, n_components=2, eigen_solver='auto'),
+    "Isomap (randomized solver)": Isomap(n_neighbors=n_neighbors, n_components=2, eigen_solver='randomized_value'),
+}
+
+projections, timing = {}, {}
+
+# Compute embeddings
+for name, transformer in embeddings.items():
+    print(f"Computing {name}...")
+    start_time = time.time()
+    projections[name] = transformer.fit_transform(X, y)
+    timing[name] = time.time() - start_time
+
+# 4- Display Results
+# ------------------
+fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+
+for ax, (name, proj) in zip(axes, projections.items()):
+    title = f"{name} (time: {timing[name]:.3f}s)"
+    plot_embedding(ax, proj, title)
+
+plt.tight_layout()
+plt.show()

--- a/benchmarks/bench_isomap_solvers_n_components_vs_reconstruction_error.py
+++ b/benchmarks/bench_isomap_solvers_n_components_vs_reconstruction_error.py
@@ -1,0 +1,66 @@
+"""
+==================================================================
+Isomap Solvers Comparison Benchmark: Reconstruction Error vs. Components
+==================================================================
+
+This benchmark demonstrates how different eigen solvers in Isomap impact the reconstruction error. The goal is to analyze the effect of varying `n_components` on the error using two solvers: 'full' and 'randomized'.
+
+Description:
+------------
+A fixed dataset (`digits` with 6 classes) is used for dimensionality reduction. The number of principal components tested varies between 2 and 500, with steps of 10.
+
+Isomap models are trained on the dataset for each value of `n_components` with two different `eigen_solver` values: 'auto' (dense) and 'randomized_value'. The reconstruction errors are computed and plotted.
+
+What you can observe:
+---------------------
+As the number of components increases, the reconstruction error is expected to decrease. The randomized solver provides an approximate solution and might yield a slightly higher error than the dense solver.
+
+Going further:
+--------------
+You can modify the range of `n_components` to observe its effect on different datasets. Additionally, experimenting with different `n_neighbors` values may impact the results.
+
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn import datasets
+from sklearn.manifold import Isomap
+
+# Function to plot reconstruction error
+def plot_reconstruction_error(n_components_list, errors_randomized, errors_full):
+    plt.figure(figsize=(10, 6))
+    plt.plot(n_components_list, errors_full, label='full', color='b', marker='*')
+    plt.plot(n_components_list, errors_randomized, label='randomized', color='r', marker='x')
+
+    plt.title('Reconstruction Error vs. Number of Components')
+    plt.xlabel('Number of Components')
+    plt.ylabel('Reconstruction Error')
+    plt.legend()
+    plt.grid(True)
+    plt.show()
+
+# Fixed dataset: Digits with 6 classes
+digits = datasets.load_digits(n_class=6)
+X, y = digits.data, digits.target
+
+# List of components to test
+n_components_list = list(range(2, 200, 10))
+
+# Initialize lists for reconstruction errors
+errors_randomized = []
+errors_full = []
+
+# Loop over different values of n_components
+for n_components in n_components_list:
+    # Create Isomap objects with different solvers
+    isomap_randomized = Isomap(n_neighbors=30, n_components=n_components, eigen_solver='randomized_value')
+    isomap_dense = Isomap(n_neighbors=30, n_components=n_components, eigen_solver='auto')
+
+    # Fit Isomap and compute reconstruction error
+    isomap_randomized.fit(X)
+    errors_randomized.append(isomap_randomized.reconstruction_error())
+    isomap_dense.fit(X)
+    errors_full.append(isomap_dense.reconstruction_error())
+
+# Plot reconstruction errors
+plot_reconstruction_error(n_components_list, errors_randomized, errors_full)

--- a/benchmarks/bench_kernel_pca_solvers_time_vs_n_components.py
+++ b/benchmarks/bench_kernel_pca_solvers_time_vs_n_components.py
@@ -78,6 +78,7 @@ X_train, X_test = X[:n_train, :], X[n_train:, :]
 ref_time = np.empty((len(n_compo_range), n_iter)) * np.nan
 a_time = np.empty((len(n_compo_range), n_iter)) * np.nan
 r_time = np.empty((len(n_compo_range), n_iter)) * np.nan
+rv_time = np.empty((len(n_compo_range), n_iter)) * np.nan
 # loop
 for j, n_components in enumerate(n_compo_range):
     n_components = int(n_components)
@@ -118,6 +119,19 @@ for j, n_components in enumerate(n_compo_range):
         r_time[j, i] = time.perf_counter() - start_time
         # check that the result is still correct despite the approximation
         assert_array_almost_equal(np.abs(r_pred), np.abs(ref_pred))
+    
+    # D- randomized_value
+    print("  - randomized_value solver")
+    for i in range(n_iter):
+        start_time = time.perf_counter()
+        rv_pred = (
+            KernelPCA(n_components, eigen_solver="randomized_value")
+            .fit(X_train)
+            .transform(X_test)
+        )
+        rv_time[j, i] = time.perf_counter() - start_time
+        # check that the result is still correct despite the approximation
+        assert_array_almost_equal(np.abs(rv_pred), np.abs(ref_pred))
 
 # Compute statistics for the 3 methods
 avg_ref_time = ref_time.mean(axis=1)
@@ -126,6 +140,8 @@ avg_a_time = a_time.mean(axis=1)
 std_a_time = a_time.std(axis=1)
 avg_r_time = r_time.mean(axis=1)
 std_r_time = r_time.std(axis=1)
+avg_rv_time = rv_time.mean(axis=1)
+std_rv_time = rv_time.std(axis=1)
 
 
 # 4- Plots
@@ -159,6 +175,15 @@ ax.errorbar(
     linestyle="",
     color="b",
     label="randomized",
+)
+ax.errorbar(
+    n_compo_range,
+    avg_rv_time,
+    yerr=std_rv_time,
+    marker="x",
+    linestyle="",
+    color="y",
+    label="randomized_value",
 )
 ax.legend(loc="upper left")
 

--- a/benchmarks/bench_kernel_pca_solvers_time_vs_n_samples.py
+++ b/benchmarks/bench_kernel_pca_solvers_time_vs_n_samples.py
@@ -80,6 +80,7 @@ X, y = make_circles(n_samples=max_n_samples, factor=0.3, noise=0.05, random_stat
 ref_time = np.empty((len(n_samples_range), n_iter)) * np.nan
 a_time = np.empty((len(n_samples_range), n_iter)) * np.nan
 r_time = np.empty((len(n_samples_range), n_iter)) * np.nan
+rv_time = np.empty((len(n_samples_range), n_iter)) * np.nan
 
 # loop
 for j, n_samples in enumerate(n_samples_range):
@@ -125,6 +126,19 @@ for j, n_samples in enumerate(n_samples_range):
         # check that the result is still correct despite the approximation
         assert_array_almost_equal(np.abs(r_pred), np.abs(ref_pred))
 
+    # D- randomized_value
+    print("  - randomized_value")
+    for i in range(n_iter):
+        start_time = time.perf_counter()
+        rv_pred = (
+            KernelPCA(n_components, eigen_solver="randomized_value")
+            .fit(X_train)
+            .transform(X_test)
+        )
+        rv_time[j, i] = time.perf_counter() - start_time
+        # check that the result is still correct despite the approximation
+        assert_array_almost_equal(np.abs(rv_pred), np.abs(ref_pred))
+
 # Compute statistics for the 3 methods
 avg_ref_time = ref_time.mean(axis=1)
 std_ref_time = ref_time.std(axis=1)
@@ -132,6 +146,8 @@ avg_a_time = a_time.mean(axis=1)
 std_a_time = a_time.std(axis=1)
 avg_r_time = r_time.mean(axis=1)
 std_r_time = r_time.std(axis=1)
+avg_rv_time = rv_time.mean(axis=1)
+std_rv_time = rv_time.std(axis=1)
 
 
 # 4- Plots
@@ -166,6 +182,16 @@ ax.errorbar(
     linestyle="",
     color="b",
     label="randomized",
+)
+
+ax.errorbar(
+    n_samples_range,
+    avg_rv_time,
+    yerr=std_rv_time,
+    marker="x",
+    linestyle="",
+    color="y",
+    label="randomized_value",
 )
 ax.legend(loc="upper left")
 

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -263,7 +263,7 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
         "kernel_params": [dict, None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "fit_inverse_transform": ["boolean"],
-        "eigen_solver": [StrOptions({"auto", "dense", "arpack", "randomized","randomized_value"})],
+        "eigen_solver": [StrOptions({"auto", "dense", "arpack", "randomized", "randomized_value"})],
         "tol": [Interval(Real, 0, None, closed="left")],
         "max_iter": [
             Interval(Integral, 1, None, closed="left"),

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -263,7 +263,7 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
         "kernel_params": [dict, None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "fit_inverse_transform": ["boolean"],
-        "eigen_solver": [StrOptions({"auto", "dense", "arpack", "randomized"})],
+        "eigen_solver": [StrOptions({"auto", "dense", "arpack", "randomized","randomized_value"})],
         "tol": [Interval(Real, 0, None, closed="left")],
         "max_iter": [
             Interval(Integral, 1, None, closed="left"),
@@ -363,6 +363,15 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
                 random_state=self.random_state,
                 selection="module",
             )
+        elif eigen_solver=="randomized_value":
+            self.eigenvalues_,self.eigenvectors_=_randomized_eigsh(
+                      K,
+                n_components=n_components,
+                n_iter=self.iterated_power,
+                random_state=self.random_state,
+                selection="value",
+            )
+
 
         # make sure that the eigenvalues are ok and fix numerical issues
         self.eigenvalues_ = _check_psd_eigenvalues(

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -37,7 +37,7 @@ def test_kernel_pca():
         assert kwargs == {}  # no kernel_params that we didn't ask for
         return np.minimum(x, y).sum()
 
-    for eigen_solver in ("auto", "dense", "arpack", "randomized"):
+    for eigen_solver in ("auto", "dense", "arpack", "randomized","randomized_value"):
         for kernel in ("linear", "rbf", "poly", histogram):
             # histogram kernel produces singular matrix inside linalg.solve
             # XXX use a least-squares approximation?
@@ -128,7 +128,7 @@ def test_kernel_pca_sparse(csr_container):
     X_fit = csr_container(rng.random_sample((5, 4)))
     X_pred = csr_container(rng.random_sample((2, 4)))
 
-    for eigen_solver in ("auto", "arpack", "randomized"):
+    for eigen_solver in ("auto", "arpack", "randomized","randomized_value"):
         for kernel in ("linear", "rbf", "poly"):
             # transform fit data
             kpca = KernelPCA(
@@ -191,7 +191,7 @@ def test_kernel_pca_n_components():
     X_fit = rng.random_sample((5, 4))
     X_pred = rng.random_sample((2, 4))
 
-    for eigen_solver in ("dense", "arpack", "randomized"):
+    for eigen_solver in ("dense", "arpack", "randomized","randomized_value"):
         for c in [1, 2, 4]:
             kpca = KernelPCA(n_components=c, eigen_solver=eigen_solver)
             shape = kpca.fit(X_fit).transform(X_pred).shape
@@ -252,7 +252,7 @@ def test_kernel_pca_precomputed():
     X_fit = rng.random_sample((5, 4))
     X_pred = rng.random_sample((2, 4))
 
-    for eigen_solver in ("dense", "arpack", "randomized"):
+    for eigen_solver in ("dense", "arpack", "randomized","randomized_value"):
         X_kpca = (
             KernelPCA(4, eigen_solver=eigen_solver, random_state=0)
             .fit(X_fit)
@@ -284,7 +284,7 @@ def test_kernel_pca_precomputed():
         assert_array_almost_equal(np.abs(X_kpca_train), np.abs(X_kpca_train2))
 
 
-@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized"])
+@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized","randomized_value"])
 def test_kernel_pca_precomputed_non_symmetric(solver):
     """Check that the kernel centerer works.
 
@@ -307,8 +307,8 @@ def test_kernel_pca_precomputed_non_symmetric(solver):
     kpca_c.fit(Kc)
 
     # comparison between the non-centered and centered versions
-    assert_array_equal(kpca.eigenvectors_, kpca_c.eigenvectors_)
     assert_array_equal(kpca.eigenvalues_, kpca_c.eigenvalues_)
+    assert_array_equal(kpca.eigenvectors_, kpca_c.eigenvectors_)
 
 
 def test_gridsearch_pipeline():
@@ -386,7 +386,7 @@ def test_kernel_conditioning():
     assert np.all(kpca.eigenvalues_ == _check_psd_eigenvalues(kpca.eigenvalues_))
 
 
-@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized"])
+@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized","randomized_value"])
 def test_precomputed_kernel_not_psd(solver):
     """Check how KernelPCA works with non-PSD kernels depending on n_components
 
@@ -440,7 +440,7 @@ def test_precomputed_kernel_not_psd(solver):
 
 @pytest.mark.parametrize("n_components", [4, 10, 20])
 def test_kernel_pca_solvers_equivalence(n_components):
-    """Check that 'dense' 'arpack' & 'randomized' solvers give similar results"""
+    """Check that 'dense' 'arpack' & 'randomized' & 'randomized_value' solvers give similar results"""
 
     # Generate random data
     n_train, n_test = 1_000, 100
@@ -473,6 +473,13 @@ def test_kernel_pca_solvers_equivalence(n_components):
     )
     # check that the result is still correct despite the approximation
     assert_array_almost_equal(np.abs(r_pred), np.abs(ref_pred))
+
+    rv_pred=(KernelPCA(n_components, eigen_solver="randomized_value", random_state=0)
+        .fit(X_fit)
+        .transform(X_pred)
+        )
+    assert_array_almost_equal(np.abs(rv_pred),np.abs(r_pred))
+
 
 
 def test_kernel_pca_inverse_transform_reconstruction():

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -37,7 +37,7 @@ def test_kernel_pca():
         assert kwargs == {}  # no kernel_params that we didn't ask for
         return np.minimum(x, y).sum()
 
-    for eigen_solver in ("auto", "dense", "arpack", "randomized","randomized_value"):
+    for eigen_solver in ("auto", "dense", "arpack", "randomized", "randomized_value"):
         for kernel in ("linear", "rbf", "poly", histogram):
             # histogram kernel produces singular matrix inside linalg.solve
             # XXX use a least-squares approximation?
@@ -128,7 +128,7 @@ def test_kernel_pca_sparse(csr_container):
     X_fit = csr_container(rng.random_sample((5, 4)))
     X_pred = csr_container(rng.random_sample((2, 4)))
 
-    for eigen_solver in ("auto", "arpack", "randomized","randomized_value"):
+    for eigen_solver in ("auto", "arpack", "randomized", "randomized_value"):
         for kernel in ("linear", "rbf", "poly"):
             # transform fit data
             kpca = KernelPCA(
@@ -191,7 +191,7 @@ def test_kernel_pca_n_components():
     X_fit = rng.random_sample((5, 4))
     X_pred = rng.random_sample((2, 4))
 
-    for eigen_solver in ("dense", "arpack", "randomized","randomized_value"):
+    for eigen_solver in ("dense", "arpack", "randomized", "randomized_value"):
         for c in [1, 2, 4]:
             kpca = KernelPCA(n_components=c, eigen_solver=eigen_solver)
             shape = kpca.fit(X_fit).transform(X_pred).shape
@@ -252,7 +252,7 @@ def test_kernel_pca_precomputed():
     X_fit = rng.random_sample((5, 4))
     X_pred = rng.random_sample((2, 4))
 
-    for eigen_solver in ("dense", "arpack", "randomized","randomized_value"):
+    for eigen_solver in ("dense", "arpack", "randomized", "randomized_value"):
         X_kpca = (
             KernelPCA(4, eigen_solver=eigen_solver, random_state=0)
             .fit(X_fit)
@@ -284,7 +284,7 @@ def test_kernel_pca_precomputed():
         assert_array_almost_equal(np.abs(X_kpca_train), np.abs(X_kpca_train2))
 
 
-@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized","randomized_value"])
+@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized", "randomized_value"])
 def test_kernel_pca_precomputed_non_symmetric(solver):
     """Check that the kernel centerer works.
 
@@ -307,9 +307,9 @@ def test_kernel_pca_precomputed_non_symmetric(solver):
     kpca_c.fit(Kc)
 
     # comparison between the non-centered and centered versions
-    assert_array_equal(kpca.eigenvalues_, kpca_c.eigenvalues_)
     assert_array_equal(kpca.eigenvectors_, kpca_c.eigenvectors_)
-
+    assert_array_equal(kpca.eigenvalues_, kpca_c.eigenvalues_)
+    
 
 def test_gridsearch_pipeline():
     """Check that kPCA works as expected in a grid search pipeline
@@ -386,7 +386,7 @@ def test_kernel_conditioning():
     assert np.all(kpca.eigenvalues_ == _check_psd_eigenvalues(kpca.eigenvalues_))
 
 
-@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized","randomized_value"])
+@pytest.mark.parametrize("solver", ["auto", "dense", "arpack", "randomized", "randomized_value"])
 def test_precomputed_kernel_not_psd(solver):
     """Check how KernelPCA works with non-PSD kernels depending on n_components
 

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -169,7 +169,7 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         "n_neighbors": [Interval(Integral, 1, None, closed="left"), None],
         "radius": [Interval(Real, 0, None, closed="both"), None],
         "n_components": [Interval(Integral, 1, None, closed="left")],
-        "eigen_solver": [StrOptions({"auto", "arpack", "dense"})],
+        "eigen_solver": [StrOptions({"auto", "arpack", "dense", "randomized_value"})],
         "tol": [Interval(Real, 0, None, closed="left")],
         "max_iter": [Interval(Integral, 1, None, closed="left"), None],
         "path_method": [StrOptions({"auto", "FW", "D"})],

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -15,7 +15,7 @@ from sklearn.utils._testing import (
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
 
-eigen_solvers = ["auto", "dense", "arpack"]
+eigen_solvers = ["auto", "dense", "arpack","randomized_value"]
 path_methods = ["auto", "FW", "D"]
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -569,7 +569,6 @@ def eigen_decomposition_one_pass(
     power_iteration_normalizer="auto",
     random_state=None
 ):
-
     xp, is_array_api_compliant = get_namespace(A)
     random_state = check_random_state(random_state)
     n_total=n_components + n_oversamples

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -559,7 +559,6 @@ def randomized_svd(
         return Vt[:n_components, :].T, s[:n_components], U[:, :n_components].T
     else:
         return U[:, :n_components], s[:n_components], Vt[:n_components, :]
-    
 
 def eigen_decomposition_one_pass(
     A, 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -561,28 +561,23 @@ def randomized_svd(
         return U[:, :n_components], s[:n_components], Vt[:n_components, :]
     
 
-
-
-
 def eigen_decomposition_one_pass(
-        A, 
-        n_components,
-        *, 
-        n_oversamples=10,
-        n_iter="auto",
-        power_iteration_normalizer="auto",
-        random_state=None
+    A, 
+    n_components,
+    *, 
+    n_oversamples=10,
+    n_iter="auto",
+    power_iteration_normalizer="auto",
+    random_state=None
 ):
-
 
     xp, is_array_api_compliant = get_namespace(A)
     random_state = check_random_state(random_state)
     n_total=n_components + n_oversamples
 
-
     Omega = xp.asarray(random_state.normal(size=(A.shape[1], n_total)))
-
-    Y = A @ Omega
+    
+    Y  = A @ Omega
     if n_iter == "auto":
         # Checks if the number of iterations is explicitly specified
         # Adjust n_iter. 7 was found a good compromise for PCA. See #5299
@@ -605,6 +600,7 @@ def eigen_decomposition_one_pass(
         Bapprox_1 = Q_H @ Y @ linalg.pinv(Q_H @ Omega)
         Bapprox = (Bapprox_1 + Bapprox_1.conj().T)/2
         S, V = linalg.eigh(Bapprox)
+    
     n=S.shape[0]
     U = Q @ V
     return S[n-n_components:],U[:, n-n_components:]
@@ -729,7 +725,7 @@ def _randomized_eigsh(
       Halko, et al. (2009)
     """
     if selection == "value":  # pragma: no cover
-        # to do : an algorithm can be found in the Halko et al reference
+        # Call Halko et al 5.6 randomized eigs solver
         eigvals, eigvecs=eigen_decomposition_one_pass(
             M,
             n_components=n_components,

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -572,7 +572,6 @@ def eigen_decomposition_one_pass(
     xp, is_array_api_compliant = get_namespace(A)
     random_state = check_random_state(random_state)
     n_total=n_components + n_oversamples
-
     Omega = xp.asarray(random_state.normal(size=(A.shape[1], n_total)))
     
     Y  = A @ Omega


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Implemented randomized_eigh(values) and integrated it into KernelPCA and Isomap. Added tests for KernelPCA and Isomap in extmath.py to ensure the decomposition is accurate. Also compared the results with other approaches, including dense methods.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
