### PR TITLE
Feature/randomized eigsh

### DIFF
--- a/benchmarks/bench_isomap_auto_vs_randomized.py
+++ b/benchmarks/bench_isomap_auto_vs_randomized.py
@@ -1,0 +1,98 @@
+"""
+======================================================================
+Benchmark: Comparing Isomap Solvers - Execution Time vs. Representation
+======================================================================
+
+This benchmark demonstrates how different eigenvalue solvers in Isomap 
+can affect execution time and embedding quality.
+
+Description:
+------------
+We use a subset of handwritten digits (`load_digits` with 6 classes). 
+Each data point is projected into a lower-dimensional space (2D) using 
+two different solvers (`auto` and `randomized`).
+
+What you can observe:
+----------------------
+- The `auto` solver provides a reference solution.
+- The `randomized` solver is tested for comparison in terms of 
+  representation quality and execution time.
+
+Further exploration:
+---------------------
+You can modify the number of neighbors (`n_neighbors`) or experiment with 
+other Isomap solvers.
+"""
+
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import offsetbox
+from sklearn.datasets import load_digits
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.manifold import Isomap
+
+# 1- Data Loading
+# ---------------
+digits = load_digits(n_class=6)
+X, y = digits.data, digits.target
+n_neighbors = 30  # Number of neighbors for Isomap
+
+# 2- Visualization Function
+# -------------------------
+def plot_embedding(ax, X, title):
+    """Displays projected points with image annotations."""
+    X = MinMaxScaler().fit_transform(X)
+
+    for digit in digits.target_names:
+        ax.scatter(
+            *X[y == digit].T,
+            marker=f"${digit}$",
+            s=60,
+            color=plt.cm.Dark2(digit),
+            alpha=0.425,
+            zorder=2,
+        )
+
+    # Add digit images in the projected space
+    shown_images = np.array([[1.0, 1.0]])
+    for i in range(X.shape[0]):
+        dist = np.sum((X[i] - shown_images) ** 2, 1)
+        if np.min(dist) < 4e-3:
+            continue
+        shown_images = np.concatenate([shown_images, [X[i]]], axis=0)
+        imagebox = offsetbox.AnnotationBbox(
+            offsetbox.OffsetImage(digits.images[i], cmap=plt.cm.gray_r), X[i]
+        )
+        imagebox.set(zorder=1)
+        ax.add_artist(imagebox)
+
+    ax.set_title(title)
+    ax.axis("off")
+
+# 3- Define Embeddings and Benchmark
+# ----------------------------------
+embeddings = {
+    "Isomap (auto solver)": Isomap(n_neighbors=n_neighbors, n_components=2, eigen_solver='auto'),
+    "Isomap (randomized solver)": Isomap(n_neighbors=n_neighbors, n_components=2, eigen_solver='randomized_value'),
+}
+
+projections, timing = {}, {}
+
+# Compute embeddings
+for name, transformer in embeddings.items():
+    print(f"Computing {name}...")
+    start_time = time.time()
+    projections[name] = transformer.fit_transform(X, y)
+    timing[name] = time.time() - start_time
+
+# 4- Display Results
+# ------------------
+fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+
+for ax, (name, proj) in zip(axes, projections.items()):
+    title = f"{name} (time: {timing[name]:.3f}s)"
+    plot_embedding(ax, proj, title)
+
+plt.tight_layout()
+plt.show()

--- a/benchmarks/bench_isomap_solvers_n_samples_vs_reconstruction_error.py
+++ b/benchmarks/bench_isomap_solvers_n_samples_vs_reconstruction_error.py
@@ -1,0 +1,85 @@
+"""
+========================================================================
+Benchmark: Isomap Reconstruction Error - Standard vs. Randomized Solver
+========================================================================
+
+This benchmark illustrates how the number of samples impacts the quality 
+of the Isomap embedding, using reconstruction error as a metric.
+
+Description:
+------------
+We generate synthetic 2D non-linear data (two concentric circles) with 
+varying numbers of samples. For each subset, we compare the reconstruction 
+error of two Isomap solvers:
+
+- The `auto` solver (standard dense or arpack, selected automatically).
+- The  `randomized_value` solver .
+
+What you can observe:
+---------------------
+- The difference in performance between the two solvers.
+
+Further exploration:
+---------------------
+- Modify the number of neighbors or iterations.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.manifold import Isomap
+from sklearn.datasets import make_circles
+
+# 1- Experiment Configuration
+# ---------------------------
+min_n_samples, max_n_samples = 100, 4000
+n_samples_grid_size = 4  # Number of sample sizes to test
+
+n_samples_range = [
+    int(min_n_samples + np.floor((x / (n_samples_grid_size - 1)) * (max_n_samples - min_n_samples)))
+    for x in range(0, n_samples_grid_size)
+]
+
+n_components = 2
+n_iter = 3  # Number of repetitions per sample size
+include_arpack = False  # Reserved for further testing
+
+# 2- Data Generation
+# ------------------
+n_features = 2
+X_full, y_full = make_circles(n_samples=max_n_samples, factor=0.3, noise=0.05, random_state=0)
+
+# 3- Benchmark Execution
+# ----------------------
+errors_randomized = []
+errors_full = []
+
+for n_samples in n_samples_range:
+    X, y = X_full[:n_samples], y_full[:n_samples]
+    print(f"Computing for n_samples = {n_samples}")
+
+    # Instantiate Isomap solvers
+    isomap_randomized = Isomap(n_neighbors=50, n_components=n_components, eigen_solver='randomized_value')
+    isomap_auto = Isomap(n_neighbors=50, n_components=n_components, eigen_solver='auto')
+
+    # Fit and record reconstruction error
+    isomap_randomized.fit(X)
+    err_rand = isomap_randomized.reconstruction_error()
+    errors_randomized.append(err_rand)
+
+    isomap_auto.fit(X)
+    err_auto = isomap_auto.reconstruction_error()
+    errors_full.append(err_auto)
+
+# 4- Results Visualization
+# ------------------------
+plt.figure(figsize=(10, 6))
+plt.scatter(n_samples_range, errors_full, label='Isomap (auto)', color='b', marker='*')
+plt.scatter(n_samples_range, errors_randomized, label='Isomap (randomized)', color='r', marker='x')
+
+plt.title('Isomap Reconstruction Error vs. Number of Samples')
+plt.xlabel('Number of Samples')
+plt.ylabel('Reconstruction Error')
+plt.legend()
+plt.grid(True)
+plt.tight_layout()
+plt.show()

--- a/benchmarks/bench_kernel_pca_solvers_time_vs_n_components.py
+++ b/benchmarks/bench_kernel_pca_solvers_time_vs_n_components.py
@@ -78,6 +78,7 @@ X_train, X_test = X[:n_train, :], X[n_train:, :]
 ref_time = np.empty((len(n_compo_range), n_iter)) * np.nan
 a_time = np.empty((len(n_compo_range), n_iter)) * np.nan
 r_time = np.empty((len(n_compo_range), n_iter)) * np.nan
+rv_time = np.empty((len(n_compo_range), n_iter)) * np.nan
 # loop
 for j, n_components in enumerate(n_compo_range):
     n_components = int(n_components)
@@ -119,6 +120,19 @@ for j, n_components in enumerate(n_compo_range):
         # check that the result is still correct despite the approximation
         assert_array_almost_equal(np.abs(r_pred), np.abs(ref_pred))
 
+    # D- randomized_value
+    print("  - randomized_value solver")
+    for i in range(n_iter):
+        start_time = time.perf_counter()
+        rv_pred = (
+            KernelPCA(n_components, eigen_solver="randomized_value")
+            .fit(X_train)
+            .transform(X_test)
+        )
+        rv_time[j, i] = time.perf_counter() - start_time
+        # check that the result is still correct despite the approximation
+        assert_array_almost_equal(np.abs(rv_pred), np.abs(ref_pred))
+
 # Compute statistics for the 3 methods
 avg_ref_time = ref_time.mean(axis=1)
 std_ref_time = ref_time.std(axis=1)
@@ -126,6 +140,8 @@ avg_a_time = a_time.mean(axis=1)
 std_a_time = a_time.std(axis=1)
 avg_r_time = r_time.mean(axis=1)
 std_r_time = r_time.std(axis=1)
+avg_rv_time = rv_time.mean(axis=1)
+std_rv_time = rv_time.std(axis=1)
 
 
 # 4- Plots
@@ -159,6 +175,15 @@ ax.errorbar(
     linestyle="",
     color="b",
     label="randomized",
+)
+ax.errorbar(
+    n_compo_range,
+    avg_rv_time,
+    yerr=std_rv_time,
+    marker="x",
+    linestyle="",
+    color="purple",
+    label="randomized_value",
 )
 ax.legend(loc="upper left")
 

--- a/benchmarks/bench_kernel_pca_solvers_time_vs_n_samples.py
+++ b/benchmarks/bench_kernel_pca_solvers_time_vs_n_samples.py
@@ -80,6 +80,7 @@ X, y = make_circles(n_samples=max_n_samples, factor=0.3, noise=0.05, random_stat
 ref_time = np.empty((len(n_samples_range), n_iter)) * np.nan
 a_time = np.empty((len(n_samples_range), n_iter)) * np.nan
 r_time = np.empty((len(n_samples_range), n_iter)) * np.nan
+rv_time = np.empty((len(n_samples_range), n_iter)) * np.nan
 
 # loop
 for j, n_samples in enumerate(n_samples_range):
@@ -125,6 +126,19 @@ for j, n_samples in enumerate(n_samples_range):
         # check that the result is still correct despite the approximation
         assert_array_almost_equal(np.abs(r_pred), np.abs(ref_pred))
 
+    # D- randomized_value
+    print("  - randomized_value")
+    for i in range(n_iter):
+        start_time = time.perf_counter()
+        rv_pred = (
+            KernelPCA(n_components, eigen_solver="randomized_value")
+            .fit(X_train)
+            .transform(X_test)
+        )
+        rv_time[j, i] = time.perf_counter() - start_time
+        # check that the result is still correct despite the approximation
+        assert_array_almost_equal(np.abs(rv_pred), np.abs(ref_pred))
+
 # Compute statistics for the 3 methods
 avg_ref_time = ref_time.mean(axis=1)
 std_ref_time = ref_time.std(axis=1)
@@ -132,7 +146,8 @@ avg_a_time = a_time.mean(axis=1)
 std_a_time = a_time.std(axis=1)
 avg_r_time = r_time.mean(axis=1)
 std_r_time = r_time.std(axis=1)
-
+avg_rv_time = rv_time.mean(axis=1)
+std_rv_time = rv_time.std(axis=1)
 
 # 4- Plots
 # --------
@@ -166,6 +181,15 @@ ax.errorbar(
     linestyle="",
     color="b",
     label="randomized",
+)
+ax.errorbar(
+    n_samples_range,
+    avg_rv_time,
+    yerr=std_rv_time,
+    marker="x",
+    linestyle="",
+    color="purple",
+    label="randomized_value",
 )
 ax.legend(loc="upper left")
 

--- a/doc/whats_new/upcoming_changes/sklearn.utils/XXXX.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/XXXX.feature.rst
@@ -1,0 +1,17 @@
+Feature
+------------
+
+- Added :func:`randomized_eigen_decomposition`, an approximate eigen decomposition method based on the approach from 
+  **Halko, Martinsson, and Tropp (2011)**: *Finding Structure with Randomness: Probabilistic Algorithms for Constructing 
+  Approximate Matrix Decompositions*. This method provides a faster alternative to existing eigen decomposition techniques.
+
+- Integrated :func:`eigen_decomposition_one_pass` into :class:`sklearn.manifold.Isomap` and 
+  :class:`sklearn.decomposition.KernelPCA` as an additional option for eigen decomposition.
+
+- Added a test suite comparing the new method to existing solvers (:obj:`arpack`, :obj:`dense`, etc.), ensuring numerical 
+  accuracy and stability.
+
+- Included benchmarks to analyze the **performance improvements** over traditional eigen decomposition approaches.
+
+by :user: `Sylvain Marié<@smarie>`, `Mohamed yaich<@yaichm>`, `Oussama Er-rabie<@eroussama>`, `Mohamed Dlimi<@Dlimim>`, 
+`Hamza Zeroual<@HamzaLuffy>` and `Amine Hannoun<@AmineHannoun>`.

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -263,7 +263,7 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
         "kernel_params": [dict, None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "fit_inverse_transform": ["boolean"],
-        "eigen_solver": [StrOptions({"auto", "dense", "arpack", "randomized"})],
+        "eigen_solver": [StrOptions({"auto", "dense", "arpack", "randomized", "randomized_value"})],
         "tol": [Interval(Real, 0, None, closed="left")],
         "max_iter": [
             Interval(Integral, 1, None, closed="left"),
@@ -362,6 +362,14 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
                 n_iter=self.iterated_power,
                 random_state=self.random_state,
                 selection="module",
+            )
+        elif eigen_solver == "randomized_value":
+            self.eigenvalues_, self.eigenvectors_ = _randomized_eigsh(
+                K,
+                n_components=n_components,
+                n_iter=self.iterated_power,
+                random_state=self.random_state,
+                selection="value",
             )
 
         # make sure that the eigenvalues are ok and fix numerical issues

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -57,6 +57,8 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         'dense' : Use a direct solver (i.e. LAPACK)
         for the eigenvalue decomposition.
 
+        'randomized_value' : Use randomized solver in order to reduce complexity.
+
     tol : float, default=0
         Convergence tolerance passed to arpack or lobpcg.
         not used if eigen_solver == 'dense'.
@@ -169,7 +171,7 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         "n_neighbors": [Interval(Integral, 1, None, closed="left"), None],
         "radius": [Interval(Real, 0, None, closed="both"), None],
         "n_components": [Interval(Integral, 1, None, closed="left")],
-        "eigen_solver": [StrOptions({"auto", "arpack", "dense"})],
+        "eigen_solver": [StrOptions({"auto", "arpack", "dense", "randomized_value"})],
         "tol": [Interval(Real, 0, None, closed="left")],
         "max_iter": [Interval(Integral, 1, None, closed="left"), None],
         "path_method": [StrOptions({"auto", "FW", "D"})],

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -15,7 +15,7 @@ from sklearn.utils._testing import (
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
 
-eigen_solvers = ["auto", "dense", "arpack"]
+eigen_solvers = ["auto", "dense", "arpack", "randomized_value"]
 path_methods = ["auto", "FW", "D"]
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -561,6 +561,92 @@ def randomized_svd(
         return U[:, :n_components], s[:n_components], Vt[:n_components, :]
 
 
+def randomized_eigen_decomposition(
+    A,
+    n_components,
+    n_oversamples=10,
+    n_iter="auto",
+    power_iteration_normalizer="auto",
+    random_state=None,
+):
+    """
+    Approximate eigenvalue decomposition of a Hermitian matrix A ≈ U Λ U*
+
+    Parameters
+    ----------
+    A : ndarray of shape (n, n)
+        Hermitian matrix to decompose.
+
+    n_components : int
+        Number of eigenvalues and eigenvectors to extract.
+
+    n_oversamples : int, default=10
+        Additional number of random vectors to sample the range of A so as to
+        ensure proper conditioning. The total number of random vectors used to
+        find the range of A is n_components + n_oversamples.
+
+    n_iter : int or "auto", default="auto"
+        Number of power iterations. Can be used to deal with slow singular
+        value decay of A. When "auto", it is set to 4 (or 7 if n_components is
+        small compared to n).
+
+    power_iteration_normalizer : {'auto', 'QR', 'LU', None}, default='auto'
+        Normalizer for power iterations. Used by randomized_range_finder.
+
+    random_state : int, RandomState instance or None, default=None
+        Pseudo-random number generator to control randomness.
+
+    Returns
+    -------
+    U : ndarray of shape (n, n_components)
+        Approximate eigenvectors.
+
+    Lambda : ndarray of shape (n_components,)
+        Approximate eigenvalues.
+
+    Notes
+    -----
+    This implementation follows Algorithm 5.3 (Direct Eigenvalue Decomposition)
+    from:
+
+        Halko, N., Martinsson, P.G., & Tropp, J.A. (2011).
+        Finding structure with randomness: Probabilistic algorithms for
+        constructing approximate matrix decompositions.
+        SIAM Review, 53(2), 217–288.
+        https://doi.org/10.1137/090771806
+    """
+    random_state = check_random_state(random_state)
+    n_random = n_components + n_oversamples
+    n = A.shape[0]
+
+    if n_iter == "auto":
+        n_iter = 7 if n_components < 0.1 * n else 4
+
+    # Step 1: compute an orthonormal matrix Q approximating the range of A
+    Q = randomized_range_finder(
+        A,
+        size=n_random,
+        n_iter=n_iter,
+        power_iteration_normalizer=power_iteration_normalizer,
+        random_state=random_state,
+    )
+
+    # Step 2: project A to the low-dimensional subspace
+    B = Q.T @ A @ Q
+
+    # Step 3: compute the eigenvalue decomposition of the small matrix
+    xp, is_array_api_compliant = get_namespace(B)
+    if is_array_api_compliant:
+        Lambda, V = xp.linalg.eigh(B)
+    else:
+        Lambda, V = linalg.eigh(B)
+
+    # Step 4: compute the approximate eigenvectors of A
+    U = Q @ V
+
+    return Lambda[-n_components:], U[:, -n_components:]
+
+
 def _randomized_eigsh(
     M,
     n_components,
@@ -647,9 +733,13 @@ def _randomized_eigsh(
     effective rank. Usually, `n_components` is chosen to be greater than k
     so increasing `n_oversamples` up to `n_components` should be enough.
 
-    Strategy 'value': not implemented yet.
-    Algorithms 5.3, 5.4 and 5.5 in the Halko et al paper should provide good
-    candidates for a future implementation.
+    Strategy 'value':
+    This randomized algorithm efficiently approximates eigendecompositions
+    of Hermitian matrices by projection onto a lower-dimensional subspace using basis Q.
+    Relying on Algorithm 5.3 from Halko et al.'s article, it computes B = Q*AQ, finds its
+    eigendecomposition B = VΛV*, and forms U = QV to yield A = UΛU*
+    with bounded error. Unlike the 'module' strategy, it works efficiently with
+    non-positive semidefinite matrices, handling both positive and negative eigenvalues directly.
 
     Strategy 'module':
     The principle is that for diagonalizable matrices, the singular values and
@@ -681,8 +771,15 @@ def _randomized_eigsh(
       Halko, et al. (2009)
     """
     if selection == "value":  # pragma: no cover
-        # to do : an algorithm can be found in the Halko et al reference
-        raise NotImplementedError()
+        # Call Hako et al 5.3 randomized eigs solver
+        eigvals, eigvecs = randomized_eigen_decomposition(
+            M,
+            n_components=n_components,
+            n_oversamples=n_oversamples,
+            n_iter=n_iter,
+            power_iteration_normalizer=power_iteration_normalizer,
+            random_state=random_state,
+        )
 
     elif selection == "module":
         # Note: no need for deterministic U and Vt (flip_sign=True),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Implemented randomized_eigh(values) and integrated it into KernelPCA and Isomap. Added tests for KernelPCA and Isomap in extmath.py to ensure the decomposition is accurate. Also compared the results with other approaches, including dense methods.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
